### PR TITLE
Digest task is working.

### DIFF
--- a/app/workers/digest_worker.rb
+++ b/app/workers/digest_worker.rb
@@ -47,7 +47,7 @@ class DigestWorker
   end
 
   def identify_and_send
-    recipients = User.wanting_digest # includes admins
+    recipients = User.wanting_digest
     if recipients.present?
       recipients.each do |recipient|
         puts "#{recipient.email} #{departments_with_comments(recipient).present?}"
@@ -59,9 +59,10 @@ class DigestWorker
   end
 
   def report_complete
-    text = '<h1>Departments With Comments</h1>'
-    text += '<p>' + @report['departments']['list'].join(', ') + '</p>' if @report['departments'].present?
+    text = ''
+    text += '<h1>Departments With Comments</h1><p>' + @report['departments']['list'].join(', ') + '</p>' if @report['departments'].present?
     text += '<h1>Digests Sent to</h1><p>' + @report['chssweb']['recipients'].join(', ') + '</p>' if @report['chssweb'].present?
+    text += '<p>No comment activity.</>' if @report['departments'].present? && !@report['chssweb'].present?
     CommentsMailer.generic(text.html_safe, "EnrollChat Digest Task Executed", 'chssweb@gmu.edu').deliver! # TBD: move email recipient to setting
     puts "Report ran fully."
   end


### PR DESCRIPTION
It's a little hard to test all of the scenarios but I think it's working. It should:

- Send digests if there were comments the previous day
- Only send each person one digest, even if they have multiple departments
- Send a report to CHSSWeb listing departments with comments and people who received digest
- Send that same report but with a note indicating that there were no results if there were no comments or nobody was set to receive the digests for the programs that had comments (this part isn't done)

Any other cases?