### PR TITLE
Move email setting to enrollchat settings

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -34,6 +34,6 @@ class SettingsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def setting_params
-      params.require(:setting).permit(:current_term, :graduate_enrollment_threshold, :undergraduate_enrollment_threshold)
+      params.require(:setting).permit(:current_term, :graduate_enrollment_threshold, :undergraduate_enrollment_threshold, :email_delivery)
     end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -35,6 +35,9 @@ class Setting < ApplicationRecord
   validates :graduate_enrollment_threshold, :undergraduate_enrollment_threshold, presence: true
   validates :email_delivery, presence: true
 
-    enum email_delivery: { scheduled: 0, off: 1, on: 2 }
+  enum email_delivery: { scheduled: 0, off: 1, on: 2 }
 
+  def self.delivery_options
+    email_deliveries.keys
+  end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -33,5 +33,8 @@ class Setting < ApplicationRecord
 
   validates :current_term, format: { with: /\d{6}/, message: 'must be blank or have exactly six numbers'}, allow_blank: true
   validates :graduate_enrollment_threshold, :undergraduate_enrollment_threshold, presence: true
+  validates :email_delivery, presence: true
+
+    enum email_delivery: { scheduled: 0, off: 1, on: 2 }
 
 end

--- a/app/views/settings/_form.html.erb
+++ b/app/views/settings/_form.html.erb
@@ -27,15 +27,19 @@
           <%= form.label :current_term %>
           <%= form.number_field :current_term, class: 'form-control mb-2', placeholder: "Current Term", 'aria-describedby': 'currentTermHelpBlock' %>
           <small id="currentTermHelpBlock" class="form-text text-muted mb-4">
-            Your password must be 8-20 characters long, contain letters and numbers, and must not contain spaces,
-            special characters,
-            or emoji.
+            Use the setting to define the current academic term.
           </small>
           <%= form.label :graduate_enrollment_threshold %>
           <%= form.number_field :graduate_enrollment_threshold, class: 'form-control mb-2' %>
 
           <%= form.label :undergraduate_enrollment_threshold %>
           <%= form.number_field :undergraduate_enrollment_threshold, class: 'form-control mb-2' %>
+
+          <%= form.label :email_delivery %>
+          <%= select :setting, :email_delivery, Setting.delivery_options, {default: 'scheduled'}, {class: 'form-control'} %>
+          <small class="form-text text-muted mb-4">
+            Use this setting to determine digest and report delivery. Options are "on", "off" and "scheduled". Scheduled is the default and uses the predefined delivery windows aligned with the University registration periods.
+          </small>
           <!-- Sign in button -->
           <%= submit_tag 'Save', class: 'btn btn-info btn-block' %>
           <%= link_to 'Cancel', sections_path, class: 'btn btn-outline-warning btn-block' %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,9 +16,5 @@ module Enrollchat
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
-
-    # Use this setting to determine digest and report delivery. Options are :on, :off and :scheduled. Scheduled uses the predefined semester schedule in lib/delivery_window.rb.
-
-    config.email_delivery = :scheduled
   end
 end

--- a/db/migrate/20190204191506_add_email_config_to_settings.rb
+++ b/db/migrate/20190204191506_add_email_config_to_settings.rb
@@ -1,0 +1,5 @@
+class AddEmailConfigToSettings < ActiveRecord::Migration[5.2]
+  def change
+    add_column :settings, :email_delivery, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_11_144120) do
+ActiveRecord::Schema.define(version: 2019_02_04_191506) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 2018_12_11_144120) do
     t.datetime "updated_at", null: false
     t.integer "graduate_enrollment_threshold", default: 10
     t.integer "undergraduate_enrollment_threshold", default: 15
+    t.integer "email_delivery", default: 0
     t.index ["singleton_guard"], name: "index_settings_on_singleton_guard", unique: true
   end
 

--- a/lib/tasks/daily_digests.rake
+++ b/lib/tasks/daily_digests.rake
@@ -5,9 +5,9 @@ namespace :daily_digests do
   include DeliveryWindows
 
   task :send_emails => :environment do
-    email_delivery = Rails.configuration.email_delivery
-    unless email_delivery == :off
-      if (email_delivery == :scheduled && delivery_window == true) || email_delivery == :on
+    email_delivery = Setting.first.email_delivery
+    unless email_delivery == "off"
+      if (email_delivery == "scheduled" && delivery_window == true) || email_delivery == "on"
         DigestWorker.perform_async()
       end
     end

--- a/lib/tasks/weekly_reports.rake
+++ b/lib/tasks/weekly_reports.rake
@@ -5,9 +5,9 @@ namespace :weekly_reports do
   include DeliveryWindows
 
   task :send_emails => :environment do
-    email_delivery = Rails.configuration.email_delivery
-    unless email_delivery == :off
-      if (email_delivery == :scheduled && delivery_window == true) || email_delivery == :on
+    email_delivery = Setting.first.email_delivery
+    unless email_delivery == "off"
+      if (email_delivery == "scheduled" && delivery_window == true) || email_delivery == "on"
         if Date.today.wday == 4
           ReportWorker.perform_async()
         end

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -5,3 +5,4 @@ one:
   singleton_guard: 0
   undergraduate_enrollment_threshold: 12
   graduate_enrollment_threshold: 10
+  email_delivery: 'scheduled'

--- a/test/integration/email_delivery_config_test.rb
+++ b/test/integration/email_delivery_config_test.rb
@@ -18,19 +18,19 @@ class EmailDeliveryConfigTest < ActionDispatch::IntegrationTest
   end
 
   test "daily digest worker is performed if email delivery config is 'on'" do
-    Rails.configuration.email_delivery = :on
+    Setting.first.update(email_delivery: "on")
     Rake::Task['daily_digests:send_emails'].invoke
     assert_equal 1, DigestWorker.jobs.size
   end
 
   test "daily digest worker is not performed if email delivery config is 'off'" do
-    Rails.application.config.email_delivery = :off
+    Setting.first.update(email_delivery: "off")
     Rake::Task['daily_digests:send_emails'].invoke
     assert_equal 0, DigestWorker.jobs.size
   end
 
   test "daily digest worker is not performed if email delivery config is 'scheduled' and delivery_window is false" do
-    Rails.application.config.email_delivery = :scheduled
+    Setting.first.update(email_delivery: "scheduled")
     travel_to Time.zone.local(2018, 10, 15, 1, 4, 44) do
       Rake::Task['daily_digests:send_emails'].invoke
       assert_equal 0, DigestWorker.jobs.size
@@ -38,7 +38,7 @@ class EmailDeliveryConfigTest < ActionDispatch::IntegrationTest
   end
 
   test "daily digest worker is performed if email delivery config is 'scheduled' and delivery_window is true" do
-    Rails.application.config.email_delivery = :scheduled
+    Setting.first.update(email_delivery: "scheduled")
     travel_to Time.zone.local(2018, 4, 15, 1, 4, 44) do
       Rake::Task['daily_digests:send_emails'].invoke
       assert_equal 1, DigestWorker.jobs.size
@@ -46,7 +46,7 @@ class EmailDeliveryConfigTest < ActionDispatch::IntegrationTest
   end
 
   test "report worker is not performed if email delivery config is 'off'" do
-    Rails.application.config.email_delivery = :off
+    Setting.first.update(email_delivery: "off")
     travel_to Time.zone.local(2018, 8, 16, 1, 4, 44) do
       Rake::Task['weekly_reports:send_emails'].invoke
       assert_equal 0, ReportWorker.jobs.size
@@ -54,7 +54,7 @@ class EmailDeliveryConfigTest < ActionDispatch::IntegrationTest
   end
 
   test "report worker is performed if email delivery config is 'on' and it is Thursday" do
-    Rails.application.config.email_delivery = :on
+    Setting.first.update(email_delivery: "on")
     travel_to Time.zone.local(2018, 8, 16, 1, 4, 44) do
       Rake::Task['weekly_reports:send_emails'].invoke
       assert_equal 1, ReportWorker.jobs.size
@@ -62,7 +62,7 @@ class EmailDeliveryConfigTest < ActionDispatch::IntegrationTest
   end
 
   test "report worker is not performed if email delivery config is 'on' and it is not Thursday" do
-    Rails.application.config.email_delivery = :on
+    Setting.first.update(email_delivery: "on")
     travel_to Time.zone.local(2018, 10, 15, 1, 4, 44) do
       Rake::Task['weekly_reports:send_emails'].invoke
       assert_equal 0, ReportWorker.jobs.size
@@ -70,7 +70,7 @@ class EmailDeliveryConfigTest < ActionDispatch::IntegrationTest
   end
 
   test "report worker is performed if email delivery config is 'scheduled', it is Thursday and delivery window is true" do
-    Rails.application.config.email_delivery = :scheduled
+    Setting.first.update(email_delivery: "scheduled")
     travel_to Time.zone.local(2018, 11, 15, 1, 4, 44) do
       Rake::Task['weekly_reports:send_emails'].invoke
       assert_equal 1, ReportWorker.jobs.size
@@ -78,7 +78,7 @@ class EmailDeliveryConfigTest < ActionDispatch::IntegrationTest
   end
 
   test "report worker is not performed if email delivery config is 'scheduled' and delivery window is false" do
-    Rails.application.config.email_delivery = :scheduled
+    Setting.first.update(email_delivery: "scheduled")
     travel_to Time.zone.local(2018, 10, 18, 1, 4, 44) do
       Rake::Task['weekly_reports:send_emails'].invoke
       assert_equal 0, ReportWorker.jobs.size

--- a/test/integration/email_delivery_config_test.rb
+++ b/test/integration/email_delivery_config_test.rb
@@ -10,6 +10,7 @@ class EmailDeliveryConfigTest < ActionDispatch::IntegrationTest
     Rake::Task.clear
     Sidekiq::Worker.clear_all
     Enrollchat::Application.load_tasks
+    @settings = settings(:one)
   end
 
   teardown do
@@ -18,19 +19,19 @@ class EmailDeliveryConfigTest < ActionDispatch::IntegrationTest
   end
 
   test "daily digest worker is performed if email delivery config is 'on'" do
-    Setting.first.update(email_delivery: "on")
+    @settings.update(email_delivery: "on")
     Rake::Task['daily_digests:send_emails'].invoke
     assert_equal 1, DigestWorker.jobs.size
   end
 
   test "daily digest worker is not performed if email delivery config is 'off'" do
-    Setting.first.update(email_delivery: "off")
+    @settings.update(email_delivery: "off")
     Rake::Task['daily_digests:send_emails'].invoke
     assert_equal 0, DigestWorker.jobs.size
   end
 
   test "daily digest worker is not performed if email delivery config is 'scheduled' and delivery_window is false" do
-    Setting.first.update(email_delivery: "scheduled")
+    @settings.update(email_delivery: "scheduled")
     travel_to Time.zone.local(2018, 10, 15, 1, 4, 44) do
       Rake::Task['daily_digests:send_emails'].invoke
       assert_equal 0, DigestWorker.jobs.size
@@ -38,7 +39,7 @@ class EmailDeliveryConfigTest < ActionDispatch::IntegrationTest
   end
 
   test "daily digest worker is performed if email delivery config is 'scheduled' and delivery_window is true" do
-    Setting.first.update(email_delivery: "scheduled")
+    @settings.update(email_delivery: "scheduled")
     travel_to Time.zone.local(2018, 4, 15, 1, 4, 44) do
       Rake::Task['daily_digests:send_emails'].invoke
       assert_equal 1, DigestWorker.jobs.size
@@ -46,7 +47,7 @@ class EmailDeliveryConfigTest < ActionDispatch::IntegrationTest
   end
 
   test "report worker is not performed if email delivery config is 'off'" do
-    Setting.first.update(email_delivery: "off")
+    @settings.update(email_delivery: "off")
     travel_to Time.zone.local(2018, 8, 16, 1, 4, 44) do
       Rake::Task['weekly_reports:send_emails'].invoke
       assert_equal 0, ReportWorker.jobs.size
@@ -54,7 +55,7 @@ class EmailDeliveryConfigTest < ActionDispatch::IntegrationTest
   end
 
   test "report worker is performed if email delivery config is 'on' and it is Thursday" do
-    Setting.first.update(email_delivery: "on")
+    @settings.update(email_delivery: "on")
     travel_to Time.zone.local(2018, 8, 16, 1, 4, 44) do
       Rake::Task['weekly_reports:send_emails'].invoke
       assert_equal 1, ReportWorker.jobs.size
@@ -62,7 +63,7 @@ class EmailDeliveryConfigTest < ActionDispatch::IntegrationTest
   end
 
   test "report worker is not performed if email delivery config is 'on' and it is not Thursday" do
-    Setting.first.update(email_delivery: "on")
+    @settings.update(email_delivery: "on")
     travel_to Time.zone.local(2018, 10, 15, 1, 4, 44) do
       Rake::Task['weekly_reports:send_emails'].invoke
       assert_equal 0, ReportWorker.jobs.size
@@ -70,7 +71,7 @@ class EmailDeliveryConfigTest < ActionDispatch::IntegrationTest
   end
 
   test "report worker is performed if email delivery config is 'scheduled', it is Thursday and delivery window is true" do
-    Setting.first.update(email_delivery: "scheduled")
+    @settings.update(email_delivery: "scheduled")
     travel_to Time.zone.local(2018, 11, 15, 1, 4, 44) do
       Rake::Task['weekly_reports:send_emails'].invoke
       assert_equal 1, ReportWorker.jobs.size
@@ -78,7 +79,7 @@ class EmailDeliveryConfigTest < ActionDispatch::IntegrationTest
   end
 
   test "report worker is not performed if email delivery config is 'scheduled' and delivery window is false" do
-    Setting.first.update(email_delivery: "scheduled")
+    @settings.update(email_delivery: "scheduled")
     travel_to Time.zone.local(2018, 10, 18, 1, 4, 44) do
       Rake::Task['weekly_reports:send_emails'].invoke
       assert_equal 0, ReportWorker.jobs.size

--- a/test/integration/worker_reporting_emails_test.rb
+++ b/test/integration/worker_reporting_emails_test.rb
@@ -8,6 +8,8 @@ class WorkerReportingEmailsTest < ActionDispatch::IntegrationTest
     Rake::Task.clear
     Sidekiq::Worker.clear_all
     Enrollchat::Application.load_tasks
+    @settings = settings(:one)
+    @settings.update(email_delivery: 'on')
   end
 
   teardown do

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -32,4 +32,16 @@ class SettingTest < ActiveSupport::TestCase
     assert_not @setting.valid?
   end
 
+  test 'email delivery cannot be null' do
+    @setting.email_delivery = nil
+    assert_not @setting.valid?
+  end
+
+  test 'returns valid email delivery options' do
+    assert_equal Setting.email_deliveries, 'scheduled' => 0, 'off' => 1, 'on' => 2
+  end
+
+  test 'returns a list of keys from the available email delivery options' do
+    assert_equal Setting.delivery_options, %w[scheduled off on]
+  end
 end

--- a/test/system/settings_test.rb
+++ b/test/system/settings_test.rb
@@ -6,24 +6,6 @@ class SettingsTest < ApplicationSystemTestCase
     @setting = settings(:one)
   end
 
-  test "visiting the index" do
-    skip
-    visit settings_url
-    assert_selector "h1", text: "Settings"
-  end
-
-  test "creating a Setting" do
-    skip
-    visit settings_url
-    click_on "New Setting"
-
-    fill_in "Current Term", with: @setting.current_term
-    click_on "Create Setting"
-
-    assert_text "Setting was successfully created"
-    click_on "Back"
-  end
-
   test "updating the undergraduate_enrollment_threshold setting" do
     visit edit_setting_url(@setting)
     fill_in "setting[undergraduate_enrollment_threshold]", with: 5
@@ -40,13 +22,11 @@ class SettingsTest < ApplicationSystemTestCase
     assert_equal Section.graduate_enrollment_threshold, 7
   end
 
-  test "destroying a Setting" do
-    skip
-    visit settings_url
-    page.accept_confirm do
-      click_on "Destroy", match: :first
-    end
-
-    assert_text "Setting was successfully destroyed"
+  test "updating the email delivery setting" do
+    visit edit_setting_url(@setting)
+    select('on', from: 'setting_email_delivery')
+    click_on 'Save'
+    assert_text "Setting was successfully updated"
+    assert_equal @setting.reload.email_delivery, 'on'
   end
 end


### PR DESCRIPTION
Move the email delivery setting from an application config set in the code, to a Setting controllable by admins.