### PR TITLE
Move mdb javascript to the bottom of the body tag to clear error caus…

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,4 +23,3 @@
 //= require users.coffee
 //= require reports.coffee
 //= require cable
-//= require material-design/mdb.min

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -96,7 +96,7 @@
       </div>
     </div>
   </footer>
-
+  <%= javascript_include_tag 'material-design/mdb.min' %>
 </body>
 
   <script type="application/javascript">

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,3 +12,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w( material-design/mdb.min.js )


### PR DESCRIPTION
…ed because it loads before the page is done loading.

This clears a lingering task we had on the board. I split the mdb js out of the application javascript rather than moving the whole application tag down. Looks okay to me, but let me now if you all think this might cause issues.
