### PR TITLE
Refactor delivery windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,12 @@ Administrators may manually upload sections in an xlsx file using the upload but
 ## Email Delivery Configuration
 
 Digest and Report emails are sent to users based on their email preferences. These emails may only be relevant during specific times of the academic year. There are three configuration settings available to control the delivery of these emails:
-- :scheduled - emails will only be sent during predefined windows. These are set in `lib/delivery_windows.rb`
+- :scheduled - emails will only be sent during predefined windows. The terms ranges for the scheduled windows can be set with the following environment variables:  
+    `term_one_start`  
+    `term_one_end`  
+    `term_two_start`  
+    `term_two_end`  
+Additional variables can be added to accommodate different academic calender structures.  
 - :on - emails will be sent on their regular schedule throughout the year
 - :off - emails will not be sent
 

--- a/lib/delivery_windows.rb
+++ b/lib/delivery_windows.rb
@@ -1,8 +1,8 @@
 module DeliveryWindows
   def delivery_window
     now = Time.zone.now
-    fall_reg_window = now.month > 3 && now.month < 10
-    spring_reg_window = now.month > 10 || now.month < 2
+    fall_reg_window = now.month >= ENV['TERM_ONE_START'].to_i && now.month <= ENV['TERM_ONE_END'].to_i
+    spring_reg_window = now.month >= ENV['TERM_TWO_START'].to_i || now.month <= ENV['TERM_TWO_END'].to_i
     if fall_reg_window
       true
     elsif spring_reg_window

--- a/test/integration/email_delivery_config_test.rb
+++ b/test/integration/email_delivery_config_test.rb
@@ -30,7 +30,7 @@ class EmailDeliveryConfigTest < ActionDispatch::IntegrationTest
     assert_equal 0, DigestWorker.jobs.size
   end
 
-  test "daily digest worker is not performed if email delivery config is 'scheduled' and delivery_window is false" do
+  test "daily digest worker is not performed if email delivery config is 'scheduled' and fall delivery_window has ended" do
     @settings.update(email_delivery: "scheduled")
     travel_to Time.zone.local(2018, 10, 15, 1, 4, 44) do
       Rake::Task['daily_digests:send_emails'].invoke
@@ -38,9 +38,25 @@ class EmailDeliveryConfigTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "daily digest worker is performed if email delivery config is 'scheduled' and delivery_window is true" do
+  test "daily digest worker is not performed if email delivery config is 'scheduled' and spring delivery_window has ended" do
+    @settings.update(email_delivery: "scheduled")
+    travel_to Time.zone.local(2018, 2, 13, 1, 4, 44) do
+      Rake::Task['daily_digests:send_emails'].invoke
+      assert_equal 0, DigestWorker.jobs.size
+    end
+  end
+
+  test "daily digest worker is performed if email delivery config is 'scheduled' and fall delivery_window is true" do
     @settings.update(email_delivery: "scheduled")
     travel_to Time.zone.local(2018, 4, 15, 1, 4, 44) do
+      Rake::Task['daily_digests:send_emails'].invoke
+      assert_equal 1, DigestWorker.jobs.size
+    end
+  end
+
+  test "daily digest worker is performed if email delivery config is 'scheduled' and spring delivery_window is true" do
+    @settings.update(email_delivery: "scheduled")
+    travel_to Time.zone.local(2018, 1, 15, 1, 4, 44) do
       Rake::Task['daily_digests:send_emails'].invoke
       assert_equal 1, DigestWorker.jobs.size
     end
@@ -70,17 +86,33 @@ class EmailDeliveryConfigTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "report worker is performed if email delivery config is 'scheduled', it is Thursday and delivery window is true" do
+  test "report worker is performed if email delivery config is 'scheduled', it is Thursday and spring delivery window is true" do
     @settings.update(email_delivery: "scheduled")
-    travel_to Time.zone.local(2018, 11, 15, 1, 4, 44) do
+    travel_to Time.zone.local(2018, 1, 18, 1, 4, 44) do
       Rake::Task['weekly_reports:send_emails'].invoke
       assert_equal 1, ReportWorker.jobs.size
     end
   end
 
-  test "report worker is not performed if email delivery config is 'scheduled' and delivery window is false" do
+  test "report worker is performed if email delivery config is 'scheduled', it is Thursday and fall delivery window is true" do
+    @settings.update(email_delivery: "scheduled")
+    travel_to Time.zone.local(2018, 4, 19, 1, 4, 44) do
+      Rake::Task['weekly_reports:send_emails'].invoke
+      assert_equal 1, ReportWorker.jobs.size
+    end
+  end
+
+  test "report worker is not performed if email delivery config is 'scheduled', it is Thursday and fall delivery window has ended" do
     @settings.update(email_delivery: "scheduled")
     travel_to Time.zone.local(2018, 10, 18, 1, 4, 44) do
+      Rake::Task['weekly_reports:send_emails'].invoke
+      assert_equal 0, ReportWorker.jobs.size
+    end
+  end
+
+  test "report worker is not performed if email delivery config is 'scheduled', it is Thursday and spring delivery window has ended" do
+    @settings.update(email_delivery: "scheduled")
+    travel_to Time.zone.local(2018, 2, 15, 1, 4, 44) do
       Rake::Task['weekly_reports:send_emails'].invoke
       assert_equal 0, ReportWorker.jobs.size
     end


### PR DESCRIPTION
…c. Add tests.

This branch refactors the DeliveryWindows module to increase flexibility and align the logic more directly to the term start and end dates. Term ranges should now be set as environment variables fitting the institution's term structure.

Moving the window ranges into settings was considered, however, that requires some design decisions that may limit flexibility in the future. The environment variables and corresponding code can be easily changed to fit a 3 semester registration structure, quarterly structure, etc.