### PR TITLE
Enable remaining Rails 6 framework defaults.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ Bundler.require(*Rails.groups)
 module Enrollchat
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults 6.0
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
@@ -24,10 +24,6 @@ module Enrollchat
         ENV[key.to_s] = value
       end if File.exist?(env_file)
     end
-
-    # remove after changing load_defaults to 6.0
-    # Uncomment when ready to test out zeitwerk loader
-    config.autoloader = :zeitwerk
 
     config.rack_cas.server_url = ENV['CAS_BASE_URL']
   end

--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -14,7 +14,7 @@ Rails.application.config.action_view.default_enforce_utf8 = false
 #
 # This option is not backwards compatible with earlier Rails versions.
 # It's best enabled when your entire app is migrated and stable on 6.0.
-# Rails.application.config.action_dispatch.use_cookies_with_metadata = true
+Rails.application.config.action_dispatch.use_cookies_with_metadata = true
 
 # Change the return value of `ActionDispatch::Response#content_type` to Content-Type header without modification.
 Rails.application.config.action_dispatch.return_only_media_type_on_content_type = false
@@ -37,7 +37,7 @@ Rails.application.config.active_storage.replace_on_assign_to_many = true
 # If you send mail in the background, job workers need to have a copy of
 # MailDeliveryJob to ensure all delivery jobs are processed properly.
 # Make sure your entire app is migrated and stable on 6.0 before using this setting.
-# Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
+Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
 
 # Enable the same cache key to be reused when the object being cached of type
 # `ActiveRecord::Relation` changes by moving the volatile information (max updated at and count)


### PR DESCRIPTION
This branch flips the remaining Rails 6 framework defaults and removes the code for testing out the zeitwerk loader. The zeitwerk loader is now turned on by the loading of the 6.0 defaults.