### PR TITLE
Allow development host

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,4 +74,6 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.action_cable.url = "ws://localhost:3000/cable"
+
+  config.hosts << ENV["DEV_HOST"]
 end


### PR DESCRIPTION
This branch adds an environment variable in config/development to whitelist a local development host.