### PR TITLE
Add the report term to the weekly email

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,4 +34,17 @@ module ApplicationHelper
     html << '</span>'.html_safe
     html unless @current_term.to_i == @term.to_i
   end
+
+  def term_in_words(term)
+    year = term.to_s[0..3]
+    term = term.to_s[4..5]
+    case term
+    when '10'
+      "Spring #{year}"
+    when '40'
+      "Summer #{year}"
+    when '70'
+      "Fall #{year}"
+    end
+  end
 end

--- a/app/helpers/sections_helper.rb
+++ b/app/helpers/sections_helper.rb
@@ -1,17 +1,4 @@
 module SectionsHelper
-  def term_in_words(term)
-    year = term.to_s[0..3]
-    term = term.to_s[4..5]
-    case term
-    when '10'
-      "Spring #{year}"
-    when '40'
-      "Summer #{year}"
-    when '70'
-      "Fall #{year}"
-    end
-  end
-
   def flagged_icon(section)
     if section.flagged_as.present?
       icon_class =     case section.flagged_as

--- a/app/views/comments_mailer/report.html.erb
+++ b/app/views/comments_mailer/report.html.erb
@@ -1,5 +1,6 @@
 <h1>EnrollChat Weekly Report</h1>
 <h2><%= basic_date(Date.today) %></h2>
+<h3>Information for <%= term_in_words(@term) %></h3>
 <p>EnrollChat provides you with up-to-date enrollment information for the current enrollment term. Log in to gather information on each class, including whether there has been an increase or decrease in enrollment over the previous reporting period. Both the Dean's Office and you have access to this data and should use EnrollChat to regularly communicate about specific courses.<p>
 <p>This report shows the enrollment state of your programs and a summary of recent comments. To change your email preferences, log into EnrollChat and click <%= link_to 'Preferences', edit_user_url(@recipient) %>.</p>
 <p>View the daily report <%= link_to 'within EnrollChat', reports_url %>.</p>

--- a/test/integration/worker_reporting_emails_test.rb
+++ b/test/integration/worker_reporting_emails_test.rb
@@ -3,6 +3,7 @@ require 'sidekiq/testing'
 
 class WorkerReportingEmailsTest < ActionDispatch::IntegrationTest
   include ActionMailer::TestHelper
+  include ApplicationHelper
 
   setup do
     Rake::Task.clear
@@ -92,6 +93,7 @@ class WorkerReportingEmailsTest < ActionDispatch::IntegrationTest
   end
 
   test "EnrollChat Report email standard content" do
+    term = @settings.current_term
     travel_to Time.zone.local(2018, 11, 15, 1, 4, 44) do
       Rake::Task['weekly_reports:send_emails'].invoke
       Sidekiq::Worker.drain_all
@@ -101,6 +103,7 @@ class WorkerReportingEmailsTest < ActionDispatch::IntegrationTest
         assert_equal [ENV['ENROLLCHAT_ADMIN_EMAIL']], email.to
         assert_equal 'EnrollChat Report (Triggered in test)', email.subject
         assert email.body.to_s.include?("<h1>EnrollChat Weekly Report</h1>")
+        assert email.body.to_s.include?("<h3>Information for #{term_in_words(term)}</h3>")
         assert email.body.to_s.include?("<p>EnrollChat provides you with up-to-date enrollment information for the current enrollment term. Log in to gather information on each class, including whether there has been an increase or decrease in enrollment over the previous reporting period. Both the Dean's Office and you have access to this data and should use EnrollChat to regularly communicate about specific courses.<p>")
         assert email.body.to_s.include?("<h2>Sections With Comments</h2>")
       end


### PR DESCRIPTION
This branch adds the term that the report data applies to in the weekly reporting email. This should help with any confusion as we switch from Spring to Summer to Fall over the next month.