### PR TITLE
Switch to sendgrid api for smtp

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,8 @@ Both the manual upload and the feed are dependent on Amazon S3 file storage, man
 * AWS_DEFAULT_REGION
 
 Emails are dependent on SendGrid, which needs these environment variables:
+* SENDGRID_API_USER
 * SENDGRID_API_KEY
-* SENDGRID_USERNAME
-* SENDGRID_PASSWORD
 
 We are using CAS for logins:
 * CAS_BASE_URL

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,8 +32,8 @@ Rails.application.configure do
   # config.active_storage.service = :local
 
   ActionMailer::Base.smtp_settings = {
-      :user_name => ENV["SENDGRID_USERNAME"],
-      :password => ENV["SENDGRID_PASSWORD"],
+      :user_name => ENV["SENDGRID_API_USER"],
+      :password => ENV["SENDGRID_API_KEY"],
       :domain => 'enrollchat.heroku.com',
       :address => 'smtp.sendgrid.net',
       :port => 587,

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,8 +75,8 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   ActionMailer::Base.smtp_settings = {
-      :user_name => ENV['SENDGRID_USERNAME'],
-      :password => ENV['SENDGRID_PASSWORD'],
+      :user_name => ENV['SENDGRID_API_USER'],
+      :password => ENV['SENDGRID_API_KEY'],
       :domain => ENV['ENROLLCHAT_HOST'],
       :address => 'smtp.sendgrid.net',
       :port => 587,


### PR DESCRIPTION
This branch switches the Sendgrid authentication to use an API key for SMTP.