### PR TITLE
Add default to cattr_accessor in Section model.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,6 +69,7 @@ Metrics/BlockLength:
 Metrics/BlockNesting:
   Exclude:
     - 'app/models/section.rb'
+    - 'lib/tasks/import.rake'
 Metrics/ClassLength:
   Exclude:
     - 'app/models/section.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -163,6 +163,7 @@ Style/NumericLiterals:
     - 'test/models/section_test.rb'
     - 'test/models/setting_test.rb'
     - 'test/system/sections_test.rb'
+    - 'test/test_helper.rb'
 Style/ClassAndModuleChildren:
   Exclude:
     - 'test/test_helper.rb'

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,8 +1,8 @@
 class Section < ApplicationRecord
   require 'roo'
 
-  cattr_accessor :graduate_enrollment_threshold
-  cattr_accessor :undergraduate_enrollment_threshold
+  cattr_accessor :graduate_enrollment_threshold, default: Setting.first.graduate_enrollment_threshold
+  cattr_accessor :undergraduate_enrollment_threshold, default: Setting.first.undergraduate_enrollment_threshold
 
   has_many :comments, -> { order(created_at: :desc) }, dependent: :destroy
   has_many :enrollments, -> { order(:created_at) }, dependent: :destroy

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -43,7 +43,7 @@ namespace :import do
           else
             file_report.report_item('Import', 'Download', "File not stored to uploader since this was called from #{Rails.env}.")
             file_report.report_item('Import', 'Download', "File not moved to backup since this was called from #{Rails.env}.")
-            File.delete("#{Rails.root}/tmp/#{new_name}") if File.exists?("#{Rails.root}/tmp/#{new_name}")
+            File.delete("#{Rails.root}/tmp/#{new_name}") if File.exist?("#{Rails.root}/tmp/#{new_name}")
             file_report.report_item('Import', 'Download', "Local copy of download file removed from #{Rails.env}.")
           end
         elsif file.key.include?(ENV["ENROLLMENT_FILE_NAME"]) && (file.key.to_s != last_file_name)

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -43,7 +43,7 @@ namespace :import do
           else
             file_report.report_item('Import', 'Download', "File not stored to uploader since this was called from #{Rails.env}.")
             file_report.report_item('Import', 'Download', "File not moved to backup since this was called from #{Rails.env}.")
-            File.delete("#{Rails.root}/tmp/#{new_name}")
+            File.delete("#{Rails.root}/tmp/#{new_name}") if File.exists?("#{Rails.root}/tmp/#{new_name}")
             file_report.report_item('Import', 'Download', "Local copy of download file removed from #{Rails.env}.")
           end
         elsif file.key.include?(ENV["ENROLLMENT_FILE_NAME"]) && (file.key.to_s != last_file_name)

--- a/test/models/section_test.rb
+++ b/test/models/section_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 
 class SectionTest < ActiveSupport::TestCase
   setup do
-    @setting = settings(:one)
     @section = sections(:one)
     @section_two = sections(:two)
     @section_three = sections(:three)

--- a/test/models/section_test.rb
+++ b/test/models/section_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class SectionTest < ActiveSupport::TestCase
   setup do
+    @setting = settings(:one)
     @section = sections(:one)
     @section_two = sections(:two)
     @section_three = sections(:three)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,8 +10,19 @@ require 'minitest/autorun'
 Capybara.server = :puma, { Silent: true }
 
 class ActiveSupport::TestCase
+  parallelize_setup do |worker|
+    Setting.create!(current_term: 201810,
+    singleton_guard: 0,
+    undergraduate_enrollment_threshold: 12,
+    graduate_enrollment_threshold: 10,
+    email_delivery: 'scheduled')
+  end
+
+  parallelize_teardown do |worker|
+    Setting.first.destroy
+  end
   # Run tests in parallel with specified workers
-  # parallelize(workers: :number_of_processors)
+  parallelize(workers: :number_of_processors)
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,15 +11,13 @@ Capybara.server = :puma, { Silent: true }
 
 class ActiveSupport::TestCase
   parallelize_setup do |worker|
-    Setting.create!(current_term: 201810,
-    singleton_guard: 0,
-    undergraduate_enrollment_threshold: 12,
-    graduate_enrollment_threshold: 10,
-    email_delivery: 'scheduled')
+    Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled')
+    SimpleCov.command_name "#{SimpleCov.command_name}-#{worker}"
   end
 
-  parallelize_teardown do |worker|
+  parallelize_teardown do
     Setting.first.destroy
+    SimpleCov.result
   end
   # Run tests in parallel with specified workers
   parallelize(workers: :number_of_processors)


### PR DESCRIPTION
This branch fixes an error in the weekly reports caused by the grad and undergrad settings not being picked up. This error was introduced during changes made while setting up the CI. In the process of fixing, we enabled parallel testing and made the necessary adjustments to get the suite passing locally and in the CI.