### PR TITLE
Update roo gem to version 2.9.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'report_action', '~> 0.4.0'
 # For processing excel files
 # Until Roo releases a new version containing a fix for Ruby 3.0.1+ we need to pull directly
 # from the source. https://github.com/roo-rb/roo/issues/551
-gem "roo", git: "https://github.com/roo-rb/roo.git"
+gem 'roo', '~> 2.9'
 
 gem 'sidekiq', '~> 6.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/roo-rb/roo.git
-  revision: 709464c77623be2bc09b2103405d90ded7604a75
-  specs:
-    roo (2.8.3)
-      nokogiri (~> 1)
-      rubyzip (>= 1.3.0, < 3.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -242,6 +234,9 @@ GEM
     regexp_parser (2.2.0)
     report_action (0.4.0)
     rexml (3.2.5)
+    roo (2.9.0)
+      nokogiri (~> 1)
+      rubyzip (>= 1.3.0, < 3.0.0)
     rubocop (1.25.1)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
@@ -355,7 +350,7 @@ DEPENDENCIES
   rake
   redis (~> 4.6)
   report_action (~> 0.4.0)
-  roo!
+  roo (~> 2.9)
   rubocop-rails (~> 2.13)
   sass-rails (~> 6.0)
   sidekiq (~> 6.4)


### PR DESCRIPTION
Bump roo to version 2.9. Remove reference to roo master branch now that Ruby 3 support has been released.