### PR TITLE
Fix recent comment display that shows UTC time when broadcasted

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,6 @@
 class CommentsController < ApplicationController
+  include ActionView::Helpers::DateHelper
+
   before_action :authenticate_user!
   before_action :set_comment, only: [:edit, :update, :destroy]
   before_action :set_user, only: [:create, :new]
@@ -32,7 +34,7 @@ class CommentsController < ApplicationController
       if @comment.save
         NewCommentWorker.perform_async(@comment.id)
         ActionCable.server.broadcast "department_channel_#{@comment.section.department}",
-                                     { message: "<a id='comment-notice-" + @comment.section.id.to_s + "' class='dropdown-item' data-toggle='modal' data-target='#comments' data-remote='true' href='/sections/" + @comment.section.id.to_s + "/comments'><i class='fa fa-circle text-info new-message-marker' aria-hidden='true'></i> ".html_safe + @comment.section.section_and_number + ": " + @comment.user.full_name + " at " + @comment.created_at.strftime('%l:%M %P') + ".</a>",
+                                     { message: "<a id='comment-notice-" + @comment.section.id.to_s + "' class='dropdown-item' data-toggle='modal' data-target='#comments' data-remote='true' href='/sections/" + @comment.section.id.to_s + "/comments'><i class='fa fa-circle text-info new-message-marker' aria-hidden='true'></i> ".html_safe + @comment.section.section_and_number + ": " + @comment.user.full_name + " " + time_ago_in_words(@comment.created_at) + "</a>",
                                        body: @comment.body,
                                        section_name: @comment.section.section_and_number,
                                        user: @comment.user.full_name,


### PR DESCRIPTION
This fixes an issue where the Activity display would show the UTC time for a just created comment. When the page was refreshed, the comment would be displayed with the `time ago in words` phrasing.

<img width="377" alt="Screen Shot 2022-06-13 at 9 52 44 AM" src="https://user-images.githubusercontent.com/7053190/173405423-3c0c94f6-d8cc-49a8-ba91-1c9844043ab3.png">

This branch updates the broadcast in the Comments controller create action so it delivers the created_at data formatted using the `time_ago_in_words` helper. This will present the most recent Activity item with the same phrasing as other activity items.

<img width="425" alt="Screen Shot 2022-06-13 at 12 45 39 PM" src="https://user-images.githubusercontent.com/7053190/173405795-b41bd440-ca02-4c74-b3e1-c5d5666cdebd.png">

We do not have an application level time zone set. It wasn't needed for this fix but if we do decide to do that at some point, the option of setting that as a User level preference is intriguing. Time related displays could then be based on the User's time zone preference.

