### PR TITLE
Ignore credentials and key. Add observer list to comments interface.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ output.html
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+config/credentials.yml.enc
+config/master.key

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
 
   has_many :comments, -> { order 'created_at DESC' }
 
-  scope :in_department, ->(department) { where("departments != '{}'").where('? = ANY(departments) OR admin is TRUE', department) }
+  scope :in_department, ->(department) { where("(? = ANY(departments) AND departments != '{}') OR admin is TRUE", department) }
 
   scope :wanting_digest, -> { where("email_preference in ('Daily Digest','Comments and Digest') or email_preference is null") }
   scope :wanting_comment_emails, -> { where("email_preference in ('All Comments','Comments and Digest')") }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
 
   has_many :comments, -> { order 'created_at DESC' }
 
-  scope :in_department, ->(department) { where("(? = ANY(departments) AND departments != '{}') OR admin is TRUE", department) }
+  scope :in_department, ->(department) { where('? = ANY(departments) OR admin is TRUE', department) }
 
   scope :wanting_digest, -> { where("email_preference in ('Daily Digest','Comments and Digest') or email_preference is null") }
   scope :wanting_comment_emails, -> { where("email_preference in ('All Comments','Comments and Digest')") }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
 
   has_many :comments, -> { order 'created_at DESC' }
 
-  scope :in_department, ->(department) { where('? = ANY(departments) OR admin is TRUE', department) }
+  scope :in_department, ->(department) { where("departments != '{}'").where('? = ANY(departments) OR admin is TRUE', department) }
 
   scope :wanting_digest, -> { where("email_preference in ('Daily Digest','Comments and Digest') or email_preference is null") }
   scope :wanting_comment_emails, -> { where("email_preference in ('All Comments','Comments and Digest')") }

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -46,6 +46,23 @@
     <%= form.text_area :body, id: :comment_body, class:"form-control" %>
   </div>
     <%= form.submit class: "btn deep-orange darken-2 btn-sm btn-block", id: 'submit' %>
+  <% observers = User.active.in_department(comment.section.department) %>
+  <p>
+    <a data-toggle="collapse" href="#collapseExample" role="button" aria-expanded="false" aria-controls="collapseExample">
+      <%= observers.size %> users are observing this department.
+    </a>
+  </p>
+  <div class="collapse" id="collapseExample">
+    <div class="card card-body">
+      <ul>
+        <% observers.each do |observer| %>
+          <li><%= observer.full_name %> (<%= observer.email_preference %>)</li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+
+
 <% end %>
 
 <script type="application/javascript">


### PR DESCRIPTION
Some of our users said they would like to know who gets notifications when they comment on a section. This adds a simple count and a collapsed list of names and email preferences.

Collapsed:
![image](https://user-images.githubusercontent.com/294724/175108702-c03b6ff2-2f6f-4cdc-9db1-71c92d864551.png)

Open:
![image](https://user-images.githubusercontent.com/294724/175109355-32abd1ad-2c47-4f30-8dc1-5a33227475c0.png)

In the course of developing this, I noticed that the scope that pulls people who are interested in a department also included people who had no department selected. This removes those people from that scope.