### PR TITLE
Marketing details

### DIFF
--- a/app/helpers/sections_helper.rb
+++ b/app/helpers/sections_helper.rb
@@ -44,4 +44,8 @@ module SectionsHelper
       Section.level_list[Section.level_code_list.find_index(level.downcase)][0]
     end
   end
+
+  def truthiness_indicator(value)
+    tag.i class: 'fa-solid fa-circle-check fa-large fa-xl' if value
+  end
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -14,6 +14,7 @@ class Section < ApplicationRecord
   scope :canceled, -> { where(status: 'C') }
   scope :not_canceled, -> { where("status <> 'C'") }
   scope :in_term, ->(term) { where(term: term) }
+  scope :upcoming, ->(term) { where('term >= ?', term)}
   scope :in_department, ->(department) { where(department: department) }
   scope :in_status, ->(status) { where(status: status) }
   scope :full_or_over_enrolled, -> { not_canceled.where('actual_enrollment >= enrollment_limit or waitlist > 5') }
@@ -83,6 +84,19 @@ class Section < ApplicationRecord
     list << 'ALL'
     list << 'ACTIVE'
     list.sort.uniq
+  end
+
+  def self.upcoming_terms(term)
+    self.upcoming(term).pluck(:term).uniq
+  end
+
+  def course_code
+    course_description.split(' ')[0]
+  end
+
+  def self.course_codes_in_term(term)
+    sections = self.in_term(term)
+    sections.collect { |section| section.course_code }.uniq.sort
   end
 
   def self.level_list

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -255,6 +255,10 @@ class Section < ApplicationRecord
     self.waitlist_yesterday = (self.new_record? || self.waitlist_was.nil?) ? 0 : waitlist_changed? ? waitlist - waitlist_was : 0
   end
 
+  def title_changed
+    title != chssweb_title
+  end
+
   def self.terms
     all.collect { |s| s.term }.uniq
   end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -269,8 +269,10 @@ class Section < ApplicationRecord
     self.waitlist_yesterday = (self.new_record? || self.waitlist_was.nil?) ? 0 : waitlist_changed? ? waitlist - waitlist_was : 0
   end
 
-  def title_changed
-    title != chssweb_title
+  def title_changed?
+    if chssweb_title.present?
+      title != chssweb_title
+    end
   end
 
   def self.terms

--- a/app/views/sections/_section.html.erb
+++ b/app/views/sections/_section.html.erb
@@ -28,5 +28,10 @@
       <%  end %>
     </td>
   <td><%=  link_to "<i class='fa fa-chart-line' aria-hidden='true' ></i> Graph".html_safe, section  %></td>
+  <td class="text-center text-success"><%= truthiness_indicator(section.title_changed?) %></td>
+  <td class="text-center text-success"><%= truthiness_indicator(section.description_present) %></td>
+  <td class="text-center text-success"><%= truthiness_indicator(section.syllabus_present) %></td>
+  <td class="text-center text-success"><%= truthiness_indicator(section.image_present) %></td>
+  <td class="text-center text-success"><%= truthiness_indicator(section.youtube_present) %></td>
   <% end %>
 </tr>

--- a/app/views/sections/_section_table.html.erb
+++ b/app/views/sections/_section_table.html.erb
@@ -22,6 +22,11 @@
       <th>Comments</th>
       <th>Graph</th>
     <% end %>
+    <th>CHSSWeb Title Changed</th>
+    <th>CHSSWeb Description</th>
+    <th>CHSSWeb Syllabus</th>
+    <th>CHSSWeb Image</th>
+    <th>CHSSWeb YouTube</th>
   </tr>
   </thead>
 

--- a/db/migrate/20220623210427_add_chssweb_title_to_section.rb
+++ b/db/migrate/20220623210427_add_chssweb_title_to_section.rb
@@ -1,0 +1,9 @@
+class AddChsswebTitleToSection < ActiveRecord::Migration[7.0]
+  def change
+    add_column :sections, :chssweb_title, :string
+    add_column :sections, :description_present, :boolean
+    add_column :sections, :syllabus_present, :boolean
+    add_column :sections, :image_present, :boolean
+    add_column :sections, :youtube_present, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,16 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[6.1].define(version: 2019_12_06_181228) do
-
+ActiveRecord::Schema[7.0].define(version: 2022_06_23_210427) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -20,8 +19,8 @@ ActiveRecord::Schema[6.1].define(version: 2019_12_06_181228) do
     t.bigint "user_id"
     t.bigint "section_id"
     t.text "body"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["section_id"], name: "index_comments_on_section_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
@@ -34,8 +33,8 @@ ActiveRecord::Schema[6.1].define(version: 2019_12_06_181228) do
     t.integer "actual_enrollment", default: 0
     t.integer "cross_list_enrollment", default: 0
     t.integer "waitlist", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["section_id"], name: "index_enrollments_on_section_id"
   end
 
@@ -55,22 +54,27 @@ ActiveRecord::Schema[6.1].define(version: 2019_12_06_181228) do
     t.integer "actual_enrollment", default: 0
     t.integer "cross_list_enrollment", default: 0
     t.integer "waitlist", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "canceled_at"
-    t.datetime "delete_at"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "canceled_at", precision: nil
+    t.datetime "delete_at", precision: nil
     t.integer "enrollment_limit_yesterday", limit: 2, default: 0, null: false
     t.integer "actual_enrollment_yesterday", limit: 2, default: 0, null: false
     t.integer "cross_list_enrollment_yesterday", limit: 2, default: 0, null: false
     t.integer "waitlist_yesterday", limit: 2, default: 0, null: false
     t.boolean "resolved_section", default: false
+    t.string "chssweb_title"
+    t.boolean "description_present"
+    t.boolean "syllabus_present"
+    t.boolean "image_present"
+    t.boolean "youtube_present"
   end
 
   create_table "settings", force: :cascade do |t|
     t.integer "current_term"
     t.integer "singleton_guard", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "graduate_enrollment_threshold", default: 10
     t.integer "undergraduate_enrollment_threshold", default: 15
     t.integer "email_delivery", default: 0
@@ -80,17 +84,17 @@ ActiveRecord::Schema[6.1].define(version: 2019_12_06_181228) do
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
+    t.datetime "current_sign_in_at", precision: nil
+    t.datetime "last_sign_in_at", precision: nil
     t.inet "current_sign_in_ip"
     t.inet "last_sign_in_ip"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "username", null: false
     t.boolean "admin", default: false
     t.string "first_name", limit: 255, null: false
     t.string "last_name", limit: 255, null: false
-    t.datetime "last_activity_check", default: -> { "now()" }
+    t.datetime "last_activity_check", precision: nil, default: -> { "now()" }
     t.string "email_preference"
     t.text "departments", default: [], array: true
     t.boolean "no_weekly_report", default: false, null: false

--- a/lib/tasks/get_marketing_info.rake
+++ b/lib/tasks/get_marketing_info.rake
@@ -1,0 +1,43 @@
+namespace :marketing_info do
+  include Rake::DSL
+
+  task :update => :environment do
+
+    # considering the time this consumes, once it's functioning it needs to go into a worker and be run in the background
+
+    require 'open-uri'
+    puts "Current term setting = #{@current_term}"
+    # determine relevant semesters - Can I presume the current term setting exists? If so, current term and all future terms that are present
+    current_term = Setting.first.current_term
+
+    terms = Section.upcoming_terms(current_term)
+    puts "Current term: #{current_term}"
+    puts terms
+    ## for each relevant term
+    terms.each do |term|
+      ## gather course codes
+      course_codes = Section.course_codes_in_term(current_term)
+      puts "Course codes: #{course_codes}"
+      course_codes.each do |course_code|
+        ### for each course code
+        puts "Looking up #{course_code} in #{current_term}"
+        ### send request to chssweb for that course code for the relevant semester
+
+        # require 'nokogiri'
+        url = URI("https://chssweb.gmu.edu/course_sections/marketing_state.json?term=#{current_term}&course_code=#{course_code}")
+        response = Net::HTTP.get(url)
+        chssweb_sections = JSON.parse(response)
+
+        puts chssweb_sections.size
+
+        chssweb_sections.each do |chssweb_section|
+          #### for each section in response
+          #### find it in enrollchat
+          section = Section.unscoped.where(section_id: chssweb_section['crn'].to_i, term: term)
+          puts "#{chssweb_section['id']} - #{section.present?}"
+          #### if any of the marketing info has changed, update it
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/get_marketing_info.rake
+++ b/lib/tasks/get_marketing_info.rake
@@ -33,9 +33,15 @@ namespace :marketing_info do
         chssweb_sections.each do |chssweb_section|
           #### for each section in response
           #### find it in enrollchat
-          section = Section.unscoped.where(section_id: chssweb_section['crn'].to_i, term: term)
+          section = Section.unscoped.where(section_id: chssweb_section['crn'].to_i, term: term).first
           puts "#{chssweb_section['id']} - #{section.present?}"
-          #### if any of the marketing info has changed, update it
+          if section.present?
+            section.assign_attributes(chssweb_title: chssweb_section['title'], image_present: chssweb_section['has_image?'], description_present: chssweb_section['has_description?'], youtube_present: chssweb_section['has_youtube?'] )
+            #### if any of the marketing info has changed, update it
+            section.save if section.changed?
+          else
+            puts "#{chssweb_section['crn']} not found in #{term}"
+          end
         end
       end
     end


### PR DESCRIPTION
This adds section marketing details from CHSSWeb, adding fields for storing those details and adding those details to the UI. It stops short of adding filtering. A follow up task should probably move the rake task into the background considering how long it takes to run.

This adds these fields to section:
- chssweb_title (string)
- description_present (boolean)
- syllabus_present (boolean)
- image_present (boolean)
- youtube_present (boolean)

I chose to add the title and to add the method "title_changed?" to section rather than adding a title_changed field and evaluating for truth during the import. This could've gone either way.

The rake task determines relevant semesters by looking at the @current_term setting. It presumes that will exist. We may need a logical fallback to max term. It then pulls all terms from that term forward, using the new method Section.upcoming_terms(term).

Then, for each term, it pulls the relevant course codes using the new method Section.course_codes_in_term(term).

For each course code in the term, it calls the CHSSWeb feed, parses the responses, searches for a matching section by crn and term, and updates that section if the marketing info has changed.

The process does not include any reporting at present.

On the front-end, we add columns for each marketing aspect. The truthiness_indicator helper displays a checkbox if passed a TRUE.

![image](https://user-images.githubusercontent.com/294724/175658486-94f434e7-c366-4780-bd6f-b24312081862.png)

The sorting for the marketing aspects does not work. It would likely work if we included any text in the response. I did not wrestle with it because we will likely eliminate datatables in the UI before we are done.
