### PR TITLE
Separate admin permission from reporting and notifications

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,6 +74,7 @@ Metrics/ClassLength:
   Exclude:
     - 'app/models/section.rb'
     - 'test/models/section_test.rb'
+    - 'test/models/user_test.rb'
     - 'test/controllers/comments_controller_test.rb'
     - 'test/controllers/users_controller_test.rb'
     - 'test/system/sections_test.rb'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
 
   has_many :comments, -> { order 'created_at DESC' }
 
-  scope :in_department, ->(department) { where('? = ANY(departments) OR admin is TRUE', department) }
+  scope :in_department, ->(department) { where('? = ANY(departments)', department) }
 
   scope :wanting_digest, -> { where("email_preference in ('Daily Digest','Comments and Digest') or email_preference is null") }
   scope :wanting_comment_emails, -> { where("email_preference in ('All Comments','Comments and Digest')") }
@@ -21,7 +21,7 @@ class User < ApplicationRecord
   end
 
   def reporting_departments
-    departments.empty? ? Section.all.pluck(:department).uniq.sort : departments
+    departments
   end
 
   def full_name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,7 +45,7 @@ class User < ApplicationRecord
   end
 
   def show_alerts(department)
-    departments.include?(department) || is_admin?
+    departments.include?(department)
   end
 
   def update_login_stats!(request)

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -45,7 +45,7 @@
                       <td><%= user.last_name %></td>
                       <td><%= user.email %></td>
                       <td><%= user.username %></td>
-                      <td><%= user.departments.blank? ? "All" : user.departments.join(', ') %></td>
+                      <td><%= user.departments.join(', ') %></td>
                       <td><%= user.email_preference %></td>
                       <td><%= user.no_weekly_report if user.no_weekly_report %></td>
                       <% if current_user.is_admin? %>

--- a/app/workers/new_comment_worker.rb
+++ b/app/workers/new_comment_worker.rb
@@ -12,7 +12,7 @@ class NewCommentWorker
     # Send that email to each user who
     # - Wants either comment emails or both comment and digest
     # - AND (has the comment's section's program selected OR has no programs selected)
-    recipients = User.in_department(@comment.section.department).wanting_comment_emails # includes admins
+    recipients = User.active.in_department(@comment.section.department).wanting_comment_emails
     if recipients.present?
       recipients.each do |recipient|
         CommentsMailer.new_comment(@comment, subject, recipient).deliver!

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -11,6 +11,28 @@ one:
   last_name: 'Gibbs'
   admin: true
   email_preference: 'All Comments'
+  departments:
+    - 'AFAM'
+    - 'BIS'
+    - 'COMM'
+    - 'CRIM'
+    - 'CULT'
+    - 'ECON'
+    - 'ENGL'
+    - 'GLOA'
+    - 'HE'
+    - 'HIST'
+    - 'HNRS'
+    - 'LA'
+    - 'MAIS'
+    - 'MCL'
+    - 'MEIS'
+    - 'PHIL'
+    - 'PSYC'
+    - 'RELI'
+    - 'SINT'
+    - 'SOAN'
+    - 'WMST'
   status: 'active'
 
 two:

--- a/test/integration/reports_test.rb
+++ b/test/integration/reports_test.rb
@@ -33,7 +33,7 @@ class ReportsTest < ActionDispatch::IntegrationTest
     assert_select 'table tbody tr td', text: '9'
   end
 
-  test 'should display the total cross-list enrollment for each deparment' do
+  test 'should display the total cross-list enrollment for each department' do
     get reports_path
     assert_select 'table tbody tr td', text: '1'
     assert_select 'table tbody tr td', text: '2'

--- a/test/integration/worker_reporting_emails_test.rb
+++ b/test/integration/worker_reporting_emails_test.rb
@@ -122,10 +122,10 @@ class WorkerReportingEmailsTest < ActionDispatch::IntegrationTest
       assert emails[1].body.to_s.include?("<td>SINT</td>")
       assert emails[1].body.to_s.include?("<td>CRIM</td>")
       assert emails[1].body.to_s.include?("<td>PHIL</td>")
-      refute emails[2].body.to_s.include?("<td>BIS</td>")
-      refute emails[2].body.to_s.include?("<td>ENGL</td>")
-      refute emails[2].body.to_s.include?("<td>SINT</td>")
-      refute emails[2].body.to_s.include?("<td>CRIM</td>")
+      assert_not emails[2].body.to_s.include?("<td>BIS</td>")
+      assert_not emails[2].body.to_s.include?("<td>ENGL</td>")
+      assert_not emails[2].body.to_s.include?("<td>SINT</td>")
+      assert_not emails[2].body.to_s.include?("<td>CRIM</td>")
     end
   end
 end

--- a/test/integration/worker_reporting_emails_test.rb
+++ b/test/integration/worker_reporting_emails_test.rb
@@ -122,10 +122,10 @@ class WorkerReportingEmailsTest < ActionDispatch::IntegrationTest
       assert emails[1].body.to_s.include?("<td>SINT</td>")
       assert emails[1].body.to_s.include?("<td>CRIM</td>")
       assert emails[1].body.to_s.include?("<td>PHIL</td>")
-      assert emails[2].body.to_s.include?("<td>BIS</td>")
-      assert emails[2].body.to_s.include?("<td>ENGL</td>")
-      assert emails[2].body.to_s.include?("<td>SINT</td>")
-      assert emails[2].body.to_s.include?("<td>CRIM</td>")
+      refute emails[2].body.to_s.include?("<td>BIS</td>")
+      refute emails[2].body.to_s.include?("<td>ENGL</td>")
+      refute emails[2].body.to_s.include?("<td>SINT</td>")
+      refute emails[2].body.to_s.include?("<td>CRIM</td>")
     end
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -40,6 +40,10 @@ class UserTest < ActiveSupport::TestCase
     assert_not test_user.is_admin?
   end
 
+  test 'returns departments of interest based on past comments' do
+    assert_equal @user.departments_of_interest, %w[CRIM]
+  end
+
   test 'should create a full name for a user' do
     @user.first_name = 'Test'
     @user.last_name = 'User'
@@ -67,12 +71,11 @@ class UserTest < ActiveSupport::TestCase
 
   test 'should determine if a user receives alerts for a department' do
     assert @user.show_alerts('PHIL')
+    assert_not @user.show_alerts('ENGL')
   end
 
-  test 'admin should receive alerts for all departments' do
-    assert @admin.show_alerts('SINT')
-    assert @admin.show_alerts('BIS')
-    assert @admin.show_alerts('PHIL')
+  test 'returns reporting departments' do
+    assert_equal @user.reporting_departments, %w[SINT CRIM PHIL]
   end
 
   test 'updates the last_activity_check for a user' do
@@ -94,6 +97,10 @@ class UserTest < ActiveSupport::TestCase
   test "status defaults to 'active' for a new user" do
     test_user = User.new(first_name: 'Test', last_name: 'User', email: 'test@mail.com', username: 'tuser')
     assert_equal test_user.status, 'active'
+  end
+
+  test 'returns valid email options' do
+    assert_equal User.email_options, ['All Comments', 'Daily Digest', 'Comments and Digest', 'No Emails']
   end
 
   test 'returns a list of keys from the available statuses' do

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -12,7 +12,7 @@ class CommentsTest < ApplicationSystemTestCase
     logout
   end
 
-  test 'comment activity feed displays the five most recent notifications for a user when there are no unread notifications and the user has no departments selected' do
+  test 'comment activity feed displays the five most recent notifications for a user when there are no unread notifications' do
     login_as(users(:one))
     visit sections_url
     click_button('Activity')


### PR DESCRIPTION
This branch separates the admin role from reporting and notification decisions. Previously, the admin role was used to assign all departments to a user for email reporting and on-screen notification purposes. We want the admin role to be reserved for permissions and have reporting and notifications be based off of the user's selected departments.

### Reporting
- The "admin is TRUE" condition has been removed from the `in_department` scope used to determines report recipients.
- The `reporting_departments` method has been changed to only include a user's departments. The condition to include all when the user's departments are blank has been removed.
- The `active` scope has been added to the recipients definition in the `NewCommnetWorker`.

### Notifications
- The `show_alerts` method on the User model has been updated so it does not include admin users. Alerts will now be only be streamed for sections belongs to departments that the user has subscribed too.

### UI
- The `All` notation that displayed on the User index when a user had no departments selected has been removed.

### Tests
- The tests have been updated to reflect these changes and additional coverage has been added to fill out the User model.

### Production changes
- I have updated the department selections for existing admin users who should continue to receive all notifications.
