### PR TITLE
Filter by modality

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -64,7 +64,7 @@ class SectionsController < ApplicationController
 
       unless params[:section][:modality].blank?
         logger.debug("MODALITY SELECTED: #{params[:section][:modality]}")
-        @modality = params[:section][:modality] if Section.modality_code_list.include?(params[:section][:modality])
+        @modality = params[:section][:modality] if Section.modality_list.include?(params[:section][:modality])
         @sections = @sections.send(@modality) if @modality.present?
       end
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -59,7 +59,13 @@ class SectionsController < ApplicationController
 
       unless params[:section][:level].blank?
         @section_level = params[:section][:level] if Section.level_code_list.include?(params[:section][:level])
-        @sections = @sections.in_level(@section_level)
+        @sections = @sections.in_level(@section_level) if @section_level.present?
+      end
+
+      unless params[:section][:modality].blank?
+        logger.debug("MODALITY SELECTED: #{params[:section][:modality]}")
+        @modality = params[:section][:modality] if Section.modality_code_list.include?(params[:section][:modality])
+        @sections = @sections.send(@modality) if @modality.present?
       end
 
       unless params[:section][:flagged].blank?

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -104,7 +104,8 @@ class Section < ApplicationRecord
   end
 
   def self.modality_list
-    [['Face to Face','face_to_face'],['Hybrid','hybrid'],['Fully Remote','fully_remote']]
+    %w[face_to_face hybrid fully_remote]
+    # [['Face to Face','face_to_face'],%w[Hybrid,hybrid],['Fully Remote','fully_remote']]
   end
 
   def self.level_list
@@ -119,8 +120,8 @@ class Section < ApplicationRecord
     self.level_list.collect { |l| l[1] }
   end
 
-  def self.modality_code_list
-    self.modality_list.collect { |l| l[1] }
+  def self.modality_list_with_labels
+    self.modality_list.map { |l| [l.humanize,l] }
   end
 
   self.level_code_list.each do |level|

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -30,7 +30,7 @@ class Section < ApplicationRecord
 
   scope :face_to_face, -> { where("modality like '_A_'") }
   scope :fully_remote, -> { where("modality like '_C_'") }
-  scope :hybrid, -> { where.not("modality like '_C_'").where.not("modality like '_A_'") }
+  scope :hybrid, -> { where.not("modality like '_C_'").where.not("modality like '_A_'").where.not(modality: [nil, '']) }
 
   scope :marked_for_deletion, -> { unscoped.where("delete_at is not null") }
   scope :delete_now, -> { unscoped.where("delete_at is not null AND delete_at < ?", DateTime.now()) }

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -107,7 +107,6 @@ class Section < ApplicationRecord
     [['Face to Face','face_to_face'],['Hybrid','hybrid'],['Fully Remote','fully_remote']]
   end
 
-
   def self.level_list
     [['Undergraduate - Lower Division','uul'],['Undergraduate - Upper Division','uuu'],['Graduate - First','ugf'],['Graduate - Advanced','uga']]
   end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -28,6 +28,10 @@ class Section < ApplicationRecord
   scope :with_status, -> { where("status is not null and status <> ' '") }
   scope :in_level, ->(level) { where("lower(level) = ?", level.downcase) }
 
+  scope :face_to_face, -> { where("modality like '_A_'") }
+  scope :fully_remote, -> { where("modality like '_C_'") }
+  scope :hybrid, -> { where.not("modality like '_C_'").where.not("modality like '_A_'") }
+
   scope :marked_for_deletion, -> { unscoped.where("delete_at is not null") }
   scope :delete_now, -> { unscoped.where("delete_at is not null AND delete_at < ?", DateTime.now()) }
 
@@ -99,6 +103,11 @@ class Section < ApplicationRecord
     sections.collect { |section| section.course_code }.uniq.sort
   end
 
+  def self.modality_list
+    [['Face to Face','face_to_face'],['Hybrid','hybrid'],['Fully Remote','fully_remote']]
+  end
+
+
   def self.level_list
     [['Undergraduate - Lower Division','uul'],['Undergraduate - Upper Division','uuu'],['Graduate - First','ugf'],['Graduate - Advanced','uga']]
   end
@@ -109,6 +118,10 @@ class Section < ApplicationRecord
 
   def self.level_code_list
     self.level_list.collect { |l| l[1] }
+  end
+
+  def self.modality_code_list
+    self.modality_list.collect { |l| l[1] }
   end
 
   self.level_code_list.each do |level|

--- a/app/views/sections/_section.html.erb
+++ b/app/views/sections/_section.html.erb
@@ -7,6 +7,7 @@
   <td><%= section.title %></td>
   <td><%= section.credits %></td>
   <td><%= level_label(section.level) %></td>
+  <td><%= section.modality_description %></td>
   <td><%= section.status %></td>
   <td><%= section.enrollment_limit %><%= yesterday_arrow(section, 'enrollment_limit') %></td>
   <td><%= section.actual_enrollment %><%= yesterday_arrow(section, 'actual_enrollment') %></td>

--- a/app/views/sections/_section_table.html.erb
+++ b/app/views/sections/_section_table.html.erb
@@ -10,6 +10,7 @@
     <th>Title</th>
     <th>Credits</th>
     <th>Level</th>
+    <th>Modality</th>
     <th>Status</th>
     <th>Enrollment Limit</th>
     <th>Actual Enrollment</th>

--- a/app/views/sections/index.html.erb
+++ b/app/views/sections/index.html.erb
@@ -34,6 +34,10 @@
                   <%= select "section", "level", options_for_select(Section.level_list, selected: @section_level), { prompt: 'ALL' }, { class: 'form-control' } %>
                 </div>
                 <div class="col-md-2 col-sm-6 form-group">
+                  <%= label_tag 'modality', 'Modality' %>
+                  <%= select "section", "modality", options_for_select(Section.modality_list, selected: @modality), { prompt: 'ALL' }, { class: 'form-control' } %>
+                </div>
+                <div class="col-md-2 col-sm-6 form-group">
                   <%= label_tag 'section_flagged', 'Flagged As' %>
                   <%= select "section", "flagged", options_for_select(Section.flagged_as_list, selected: @flagged_as), { prompt: 'ALL' }, { class: 'form-control' } %>
                 </div>

--- a/app/views/sections/index.html.erb
+++ b/app/views/sections/index.html.erb
@@ -35,7 +35,7 @@
                 </div>
                 <div class="col-md-2 col-sm-6 form-group">
                   <%= label_tag 'modality', 'Modality' %>
-                  <%= select "section", "modality", options_for_select(Section.modality_list, selected: @modality), { prompt: 'ALL' }, { class: 'form-control' } %>
+                  <%= select "section", "modality", options_for_select(Section.modality_list_with_labels, selected: @modality), { prompt: 'ALL' }, { class: 'form-control' } %>
                 </div>
                 <div class="col-md-2 col-sm-6 form-group">
                   <%= label_tag 'section_flagged', 'Flagged As' %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,26 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Dangerous Send",
+      "warning_code": 23,
+      "fingerprint": "dbdbeb8831c45c8077cec5cd8fdab908c3f6db4dbf57e4e97cf28d24c4f0b6eb",
+      "check_name": "Send",
+      "message": "User controlled method execution",
+      "file": "app/controllers/sections_controller.rb",
+      "line": 68,
+      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
+      "code": "Section.includes(:comments).in_term((params[:term] or (cookies[:term] or (Setting.first_or_create!(:singleton_guard => 0).current_term or Section.maximum(:term))))).by_department.by_section_and_number.not_canceled.in_department(params[:section][:department]).not_canceled.not_canceled.in_status(params[:section][:status]).in_level(params[:section][:level]).send(params[:section][:modality])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "SectionsController",
+        "method": "filter"
+      },
+      "user_input": "params[:section][:modality]",
+      "confidence": "High",
+      "note": ""
+    }
+  ],
+  "updated": "2022-08-18 08:19:41 -0400",
+  "brakeman_version": "5.2.3"
+}

--- a/test/models/section_test.rb
+++ b/test/models/section_test.rb
@@ -135,6 +135,23 @@ class SectionTest < ActiveSupport::TestCase
     assert_equal @sections.in_level(level), [@section_two, @section_five]
   end
 
+  test 'face_to_face scope should return sections whose modality matches _A_.' do
+    @section.update(modality: 'XAX')
+    assert_equal @sections.face_to_face, [@section]
+  end
+
+  test 'fully_remote scope should return sections whose modality matches _C_.' do
+    @section.update(modality: 'XCX')
+    assert_equal @sections.fully_remote, [@section]
+  end
+
+  test 'hybrid scope should return sections which have a modality and whose modality is not _A_ or _C_.' do
+    @section.update(modality: 'XXX')
+    @section_two.update(modality: 'XAX')
+    @section_three.update(modality: 'XCX')
+    assert_equal @sections.hybrid, [@section]
+  end
+
   # import
   test 'import updates attributes for the first existing section' do
     assert_equal @section.actual_enrollment, 22


### PR DESCRIPTION
This adds the UI for modality display and filtering.

The modality now appears after level in the listing and in the filter interface.
![image](https://user-images.githubusercontent.com/294724/185244165-709d5464-0f27-40af-b82f-e1d318133bea.png)

Based on feedback from Lisa, we mask the 15 modality types down to three (plus the "ALL" option):

- Face to Face
- Hybrid
- Fully Remote

We have a scope for each, with tests for the scope. The scopes rely on the consistency of the naming convention, so if Mason sticks to that convention it should accommodate additional scopes unknown to us or created in the future.