### PR TITLE
Bring in instructor names. Add to display.

### DIFF
--- a/app/assets/javascripts/sections.js
+++ b/app/assets/javascripts/sections.js
@@ -78,8 +78,8 @@ $(document).ready(function() {
             },
             { responsivePriority: 1, targets: [
                     4,
-                    !$('body').hasClass('sections') || !$('body').hasClass('show') ? 16 : undefined,
-                    !$('body').hasClass('sections') || !$('body').hasClass('show') ? 17 : undefined
+                    !$('body').hasClass('sections') || !$('body').hasClass('show') ? 17 : undefined,
+                    !$('body').hasClass('sections') || !$('body').hasClass('show') ? 18 : undefined
                 ]
             },
             { responsivePriority: 2, targets: [
@@ -87,11 +87,11 @@ $(document).ready(function() {
                 ]
             },
             { responsivePriority: 3, targets: [
-                    9,
                     10,
                     11,
                     12,
-                    13
+                    13,
+                    14
                 ]
             }
         ],

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -243,6 +243,10 @@ class Section < ApplicationRecord
     level[0..12].downcase == 'uu'
   end
 
+  def instructor_names
+    [instructor_name, second_instructor_name].compact.join(' and ')
+  end
+
   def flagged_as
     # It would be nice to add highlights to low enrolled courses.  The rules for this are a bit complicated.  An undergraduate course would get a highlight if its actual enrolled were under 15 and its crosslist enrolled were also under 15 (e.g. a course with 7 actual enrolled and 16 crosslist enrolled should not be highlighted).  A graduate course would be highlighted if its actual enrolled were under 10 and its cross list enrolled were under 10.  One more wrinkle, that we could ignore.  An undergraduate course should be treated as if it were a graduate course viz. these minimums if it is linked to a grad course with a cross list code.  Again, this last rule could be disregarded if that kind of check is hard to program and/or would slow down the program considerably. (The logic here is that if a course is cross listed as a grad/undergrad course, I have given the benefit of the doubt at treated it as a grad course with the min. enrollment at 10--probably an overly generous policy.)
     # The might also be a different highlight color for any course with a WL above 5.

--- a/app/views/sections/_section.html.erb
+++ b/app/views/sections/_section.html.erb
@@ -8,6 +8,7 @@
   <td><%= section.credits %></td>
   <td><%= level_label(section.level) %></td>
   <td><%= section.modality_description %></td>
+  <td><%= section.instructor_names %></td>
   <td><%= section.status %></td>
   <td><%= section.enrollment_limit %><%= yesterday_arrow(section, 'enrollment_limit') %></td>
   <td><%= section.actual_enrollment %><%= yesterday_arrow(section, 'actual_enrollment') %></td>

--- a/app/views/sections/_section_table.html.erb
+++ b/app/views/sections/_section_table.html.erb
@@ -11,6 +11,7 @@
     <th>Credits</th>
     <th>Level</th>
     <th>Modality</th>
+    <th>Instructor(s)</th>
     <th>Status</th>
     <th>Enrollment Limit</th>
     <th>Actual Enrollment</th>

--- a/db/migrate/20220820203515_add_instructor_to_section.rb
+++ b/db/migrate/20220820203515_add_instructor_to_section.rb
@@ -1,0 +1,6 @@
+class AddInstructorToSection < ActiveRecord::Migration[7.0]
+  def change
+    add_column :sections, :instructor_name, :string
+    add_column :sections, :second_instructor_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_02_183902) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_20_203515) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -71,6 +71,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_02_183902) do
     t.string "modality"
     t.string "modality_description"
     t.string "print_flag"
+    t.string "instructor_name"
+    t.string "second_instructor_name"
   end
 
   create_table "settings", force: :cascade do |t|

--- a/lib/tasks/get_marketing_info.rake
+++ b/lib/tasks/get_marketing_info.rake
@@ -38,7 +38,7 @@ namespace :marketing_info do
             section = Section.unscoped.where(section_id: chssweb_section['crn'].to_i, term: term).first
             puts "#{chssweb_section['id']} - #{section.present?}"
             if section.present?
-              section.assign_attributes(chssweb_title: chssweb_section['title'], image_present: chssweb_section['has_image?'], description_present: chssweb_section['has_description?'], youtube_present: chssweb_section['has_youtube?'])
+              section.assign_attributes(chssweb_title: chssweb_section['title'], image_present: chssweb_section['has_image?'], description_present: chssweb_section['has_description?'], youtube_present: chssweb_section['has_youtube?'], instructor_name: chssweb_section['instructor_name'], second_instructor_name: chssweb_section['second_instructor_name'])
               #### if any of the marketing info has changed, update it
               section.save if section.changed?
             else

--- a/lib/tasks/get_marketing_info.rake
+++ b/lib/tasks/get_marketing_info.rake
@@ -39,6 +39,7 @@ namespace :marketing_info do
             puts "#{chssweb_section['id']} - #{section.present?}"
             if section.present?
               section.assign_attributes(chssweb_title: chssweb_section['title'], image_present: chssweb_section['has_image?'], description_present: chssweb_section['has_description?'], youtube_present: chssweb_section['has_youtube?'], instructor_name: chssweb_section['instructor_name'], second_instructor_name: chssweb_section['second_instructor_name'])
+              section.second_instructor_name = nil if section.instructor_name == section.second_instructor_name
               #### if any of the marketing info has changed, update it
               section.save if section.changed?
             else


### PR DESCRIPTION
This adds two fields: instructor_name and second_instructor name. It adds a method that returns both names separated by an and if both are present, one if only one is present, and nothing if there are no names. (It's actually harder to describe than it was to code.) It adds to those to the section listing and adds those fields to the marketing import.