### PR TITLE
Import meeting information

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -64,4 +64,4 @@ jobs:
           PGUSER: postgres
           RAILS_ENV: test
         run: |
-          bin/rails test:system test
+          bin/rails test:all

--- a/README.md
+++ b/README.md
@@ -94,10 +94,20 @@ Additional variables can be added to accommodate different academic calender str
 - :on - emails will be sent on their regular schedule throughout the year
 - :off - emails will not be sent
 
+## Marketing Feed
+
+An optional feed of marketing related data can be configured. The application settings allows the configuration of a data feed uri. This uri is used in the `marketing_info` rake task. This task is fairly specific but could be modified to work with specific data feeds and formats. One of the attributes it currently injests are campus codes. If there is a need to display specific labels for campus codes, those can be configured using the following environment variable pattern:
+    `CAMPUS_CODE_ONE`
+    `CAMPUS_LABEL_ONE`
+    `CAMPUS_CODE_TWO`
+    `CAMPUS_LABEL_TWO`
+
+These apply specifically to the `campus_label` method in the Section model. Currently, up to 11 codes and 9 labels can be used.
+
 ## Testing
 
 The app uses Rails' built in testing mechanisms. System Tests are configured to inherit from Capybara and run Selenium with headless Chrome. Chromedriver is required to use this setup. The webdrivers gem is included to provide installation and support for chromedriver.
 
 To run tests: `bin/rails test`  
 To run system tests: `bin/rails test:system`  
-To run all tests: `bin/rails test:system test`
+To run all tests: `bin/rails test:all`

--- a/app/assets/javascripts/sections.js
+++ b/app/assets/javascripts/sections.js
@@ -78,8 +78,8 @@ $(document).ready(function() {
             },
             { responsivePriority: 1, targets: [
                     4,
-                    !$('body').hasClass('sections') || !$('body').hasClass('show') ? 17 : undefined,
-                    !$('body').hasClass('sections') || !$('body').hasClass('show') ? 18 : undefined
+                    !$('body').hasClass('sections') || !$('body').hasClass('show') ? 20 : undefined,
+                    !$('body').hasClass('sections') || !$('body').hasClass('show') ? 21 : undefined
                 ]
             },
             { responsivePriority: 2, targets: [

--- a/app/assets/javascripts/sections.js
+++ b/app/assets/javascripts/sections.js
@@ -88,8 +88,8 @@ $(document).ready(function() {
             },
             { responsivePriority: 3, targets: [
                     5,
-                    9,
-                    12
+                    11,
+                    14
                 ]
 
             },
@@ -97,10 +97,10 @@ $(document).ready(function() {
                     6,
                     7,
                     8,
-                    10,
-                    11,
+                    12,
                     13,
-                    14
+                    15,
+                    16
                 ]
             }
         ],

--- a/app/helpers/sections_helper.rb
+++ b/app/helpers/sections_helper.rb
@@ -48,4 +48,8 @@ module SectionsHelper
   def truthiness_indicator(value)
     tag.i class: 'fa-solid fa-circle-check fa-large fa-xl' if value
   end
+
+  def day_and_time(section)
+    "#{section.days} #{section.formatted_time(section.start_time)}-#{section.formatted_time(section.end_time)}"
+  end
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -308,7 +308,7 @@ class Section < ApplicationRecord
   end
 
   def formatted_time(time)
-    time.to_datetime.strftime("%-I:%M%p") if time
+    time&.to_datetime&.strftime("%-I:%M%p")
   end
 
   def campus_label

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -306,4 +306,33 @@ class Section < ApplicationRecord
       Section.in_term(term).update_all(delete_at: Time.now.next_month)
     end
   end
+
+  def formatted_time(time)
+    time.to_datetime.strftime("%-I:%M%p") if time
+  end
+
+  def campus_label
+    case campus_code
+    when 'KOR'
+      'Mason Korea Campus'
+    when 'AR'
+      'Arlington Campus'
+    when 'FX'
+      'Fairfax Campus'
+    when 'FR'
+      'Front Royal'
+    when 'SA'
+      'Study Abroad'
+    when 'NE', 'MOL'
+      'Mason Online'
+    when 'OC', 'OCB'
+      'Off Campus'
+    when 'LC'
+      'Loudon Campus'
+    when 'PW'
+      'Science and Technology Campus'
+    else
+      campus_code
+    end
+  end
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -313,24 +313,24 @@ class Section < ApplicationRecord
 
   def campus_label
     case campus_code
-    when 'KOR'
-      'Mason Korea Campus'
-    when 'AR'
-      'Arlington Campus'
-    when 'FX'
-      'Fairfax Campus'
-    when 'FR'
-      'Front Royal'
-    when 'SA'
-      'Study Abroad'
-    when 'NE', 'MOL'
-      'Mason Online'
-    when 'OC', 'OCB'
-      'Off Campus'
-    when 'LC'
-      'Loudon Campus'
-    when 'PW'
-      'Science and Technology Campus'
+    when ENV.fetch('CAMPUS_CODE_ONE', nil)
+      ENV.fetch('CAMPUS_LABEL_ONE', nil)
+    when ENV.fetch('CAMPUS_CODE_TWO', nil)
+      ENV.fetch('CAMPUS_LABEL_TWO', nil)
+    when ENV.fetch('CAMPUS_CODE_THREE', nil)
+      ENV.fetch('CAMPUS_LABEL_THREE', nil)
+    when ENV.fetch('CAMPUS_CODE_FOUR', nil)
+      ENV.fetch('CAMPUS_LABEL_FOUR', nil)
+    when ENV.fetch('CAMPUS_CODE_FIVE', nil)
+      ENV.fetch('CAMPUS_LABEL_FIVE', nil)
+    when ENV.fetch('CAMPUS_CODE_SIX', nil), ENV.fetch('CAMPUS_CODE_TEN', nil)
+      ENV.fetch('CAMPUS_LABEL_SIX', nil)
+    when ENV.fetch('CAMPUS_CODE_SEVEN', nil), ENV.fetch('CAMPUS_CODE_ELEVEN', nil)
+      ENV.fetch('CAMPUS_LABEL_SEVEN', nil)
+    when ENV.fetch('CAMPUS_CODE_EIGHT', nil)
+      ENV.fetch('CAMPUS_LABEL_EIGHT', nil)
+    when ENV.fetch('CAMPUS_CODE_NINE', nil)
+      ENV.fetch('CAMPUS_LABEL_NINE', nil)
     else
       campus_code
     end

--- a/app/views/sections/_section.html.erb
+++ b/app/views/sections/_section.html.erb
@@ -8,6 +8,8 @@
   <td><%= section.credits %></td>
   <td><%= level_label(section.level) %></td>
   <td><%= section.modality_description %></td>
+  <td><%= day_and_time(section) %></td>
+  <td><%= section.campus_label %></td>
   <td><%= section.instructor_names %></td>
   <td><%= section.status %></td>
   <td><%= section.enrollment_limit %><%= yesterday_arrow(section, 'enrollment_limit') %></td>

--- a/app/views/sections/_section_table.html.erb
+++ b/app/views/sections/_section_table.html.erb
@@ -11,6 +11,8 @@
     <th>Credits</th>
     <th>Level</th>
     <th>Modality</th>
+    <th>Meeting</th>
+    <th>Campus</th>
     <th>Instructor(s)</th>
     <th>Status</th>
     <th>Enrollment Limit</th>

--- a/db/migrate/20221206162054_add_meeting_data_to_sections.rb
+++ b/db/migrate/20221206162054_add_meeting_data_to_sections.rb
@@ -1,0 +1,8 @@
+class AddMeetingDataToSections < ActiveRecord::Migration[7.0]
+  def change
+    add_column :sections, :days, :string
+    add_column :sections, :start_time, :string
+    add_column :sections, :end_time, :string
+    add_column :sections, :campus_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_20_203515) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_06_162054) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -73,6 +73,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_20_203515) do
     t.string "print_flag"
     t.string "instructor_name"
     t.string "second_instructor_name"
+    t.string "days"
+    t.string "start_time"
+    t.string "end_time"
+    t.string "campus_code"
   end
 
   create_table "settings", force: :cascade do |t|

--- a/lib/tasks/get_marketing_info.rake
+++ b/lib/tasks/get_marketing_info.rake
@@ -48,7 +48,8 @@ namespace :marketing_info do
                 days: chssweb_section['days'],
                 start_time: chssweb_section['start_time'],
                 end_time: chssweb_section['end_time'],
-                campus_code: chssweb_section['campus_code'])
+                campus_code: chssweb_section['campus_code']
+              )
               section.second_instructor_name = nil if section.instructor_name == section.second_instructor_name
               #### if any of the marketing info has changed, update it
               section.save if section.changed?

--- a/lib/tasks/get_marketing_info.rake
+++ b/lib/tasks/get_marketing_info.rake
@@ -38,7 +38,17 @@ namespace :marketing_info do
             section = Section.unscoped.where(section_id: chssweb_section['crn'].to_i, term: term).first
             puts "#{chssweb_section['id']} - #{section.present?}"
             if section.present?
-              section.assign_attributes(chssweb_title: chssweb_section['title'], image_present: chssweb_section['has_image?'], description_present: chssweb_section['has_description?'], youtube_present: chssweb_section['has_youtube?'], instructor_name: chssweb_section['instructor_name'], second_instructor_name: chssweb_section['second_instructor_name'])
+              section.assign_attributes(
+                chssweb_title: chssweb_section['title'],
+                image_present: chssweb_section['has_image?'],
+                description_present: chssweb_section['has_description?'],
+                youtube_present: chssweb_section['has_youtube?'],
+                instructor_name: chssweb_section['instructor_name'],
+                second_instructor_name: chssweb_section['second_instructor_name'],
+                days: chssweb_section['days'],
+                start_time: chssweb_section['start_time'],
+                end_time: chssweb_section['end_time'],
+                campus_code: chssweb_section['campus_code'])
               section.second_instructor_name = nil if section.instructor_name == section.second_instructor_name
               #### if any of the marketing info has changed, update it
               section.save if section.changed?

--- a/test/helpers/sections_helper_test.rb
+++ b/test/helpers/sections_helper_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class SectionHelperTest < ActionView::TestCase
+  include SectionsHelper
+
+  setup do
+    @section = sections(:one)
+  end
+
+  test "combines section day and time into a string for display" do
+    @section.update(days: "TR", start_time: "10:30", end_time: "13:20")
+    assert_equal day_and_time(@section), "#{@section.days} #{@section.formatted_time(@section.start_time)}-#{@section.formatted_time(@section.end_time)}"
+  end
+end

--- a/test/models/section_test.rb
+++ b/test/models/section_test.rb
@@ -332,6 +332,10 @@ class SectionTest < ActiveSupport::TestCase
     assert_equal @section.formatted_time(@section.start_time), "4:30PM"
   end
 
+  test 'returns nil if no time' do
+    assert_nil @section.formatted_time(@section.start_time)
+  end
+
   test 'returns the label for a known campus code' do
     @section.update(campus_code: 'LC')
     assert_equal @section.campus_label, 'Loudon Campus'

--- a/test/models/section_test.rb
+++ b/test/models/section_test.rb
@@ -326,4 +326,19 @@ class SectionTest < ActiveSupport::TestCase
     assert_not_nil @section_four.reload.delete_at
     assert_not_nil @section_five.reload.delete_at
   end
+
+  test 'translates 24-hour time string into formatted 12-hour time' do
+    @section.update(start_time: "16:30")
+    assert_equal @section.formatted_time(@section.start_time), "4:30PM"
+  end
+
+  test 'returns the label for a known campus code' do
+    @section.update(campus_code: 'LC')
+    assert_equal @section.campus_label, 'Loudon Campus'
+  end
+
+  test 'returns the campus code for an known campus code' do
+    @section.update(campus_code: 'ABC')
+    assert_equal @section.campus_label, 'ABC'
+  end
 end

--- a/test/models/section_test.rb
+++ b/test/models/section_test.rb
@@ -337,8 +337,8 @@ class SectionTest < ActiveSupport::TestCase
   end
 
   test 'returns the label for a known campus code' do
-    @section.update(campus_code: 'LC')
-    assert_equal @section.campus_label, 'Loudon Campus'
+    @section.update(campus_code: 'VA')
+    assert_equal @section.campus_label, 'Virginia Campus'
   end
 
   test 'returns the campus code for an known campus code' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,4 +45,6 @@ class ActionDispatch::IntegrationTest
   ENV['TERM_ONE_END'] = '9'
   ENV['TERM_TWO_START'] = '11'
   ENV['TERM_TWO_END'] = '1'
+  ENV['CAMPUS_CODE_ONE'] = 'VA'
+  ENV['CAMPUS_LABEL_ONE'] = 'Virginia Campus'
 end


### PR DESCRIPTION
This branch adds meeting and campus information to course sections. The marketing_info rake task has been updated to accept the new attributes and methods have been added to normalize and format the data for display. Specifically, we combine the meeting days and times into a single display and format the campus code into a descriptive label. The campus code and campus label are configured as environment variables. These could eventually be made configurable settings, accessible through the user interface.

Visually, the new meeting and campus columns have not been given a priority settings for the responsive table so they will fall into the expandable view on smaller screen sizes.