### PR TITLE
Add configurable documentation link.

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -34,6 +34,6 @@ class SettingsController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the permit list through.
   def setting_params
-    params.require(:setting).permit(:current_term, :graduate_enrollment_threshold, :undergraduate_enrollment_threshold, :email_delivery, :data_feed_uri)
+    params.require(:setting).permit(:current_term, :graduate_enrollment_threshold, :undergraduate_enrollment_threshold, :email_delivery, :data_feed_uri, :documentation_url)
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -95,7 +95,7 @@
   <footer class="page-footer unique-color-dark text-white center-on-small-only">
     <div class="footer-copyright">
       <div class="container-fluid">
-        A product of the <a href="mailto:chssweb@gmu.edu">CHSSWeb</a> Team&nbsp; • &nbsp; &copy; <%= Time.now.year %> Copyright George Mason University
+        A product of the <a href="mailto:chssweb@gmu.edu">CHSSWeb</a> Team&nbsp; • &nbsp; &copy; <%= Time.now.year %> Copyright George Mason University <% if Setting.first.documentation_url.present? %>&nbsp; • &nbsp;<a href="<%= Setting.first.documentation_url %>" target="_blank">EnrollChat Information and Updates</a><% end %>
       </div>
     </div>
   </footer>

--- a/app/views/settings/_form.html.erb
+++ b/app/views/settings/_form.html.erb
@@ -46,6 +46,12 @@
           <small class="form-text text-muted mb-4">
             Use this optional setting to set the URL for a data feed URL to be used in a rake task.
           </small>
+
+          <%= form.label :documentation_url %>
+          <%= form.text_field :documentation_url, class: 'form-control mb-2' %>
+          <small class="form-text text-muted mb-4">
+            Use this optional setting to set the URL for online documentation resources.
+          </small>
           <%= submit_tag 'Save', class: 'btn btn-large deep-orange darken-2' %>
           <%= link_to 'Cancel', sections_path, class: 'btn btn-large yellow darken-2' %>
         <% end %>

--- a/db/migrate/20230110211101_add_documentation_url_to_settings.rb
+++ b/db/migrate/20230110211101_add_documentation_url_to_settings.rb
@@ -1,0 +1,5 @@
+class AddDocumentationUrlToSettings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :settings, :documentation_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_06_162054) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_10_211101) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -88,6 +88,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_06_162054) do
     t.integer "undergraduate_enrollment_threshold", default: 15
     t.integer "email_delivery", default: 0
     t.string "data_feed_uri"
+    t.string "documentation_url"
     t.index ["singleton_guard"], name: "index_settings_on_singleton_guard", unique: true
   end
 

--- a/test/system/settings_test.rb
+++ b/test/system/settings_test.rb
@@ -33,4 +33,15 @@ class SettingsTest < ApplicationSystemTestCase
     assert_text "Setting was successfully updated"
     assert_equal @setting.reload.email_delivery, 'on'
   end
+
+  test "documentation link is optional" do
+    visit sections_url
+    refute_text "EnrollChat Information and Updates"
+  end
+
+  test "display documentation link when it is set" do
+    @setting.update(documentation_url: "https://testdoclink.com")
+    visit sections_url
+    assert_text 'EnrollChat Information and Updates'
+  end
 end


### PR DESCRIPTION
This branch adds a configurable documentation url to Settings. If present the link will display in the footer with the text "EnrollChat Information and Updates".

<img width="311" alt="Screen Shot 2023-01-10 at 4 28 11 PM" src="https://user-images.githubusercontent.com/7053190/211667475-6f9ce715-17f1-4107-85d9-520e8f171ebf.png">
