### PR TITLE
Update table and data headings with new phrasing

### DIFF
--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -30,12 +30,12 @@
         <%= "Enrollment Limit: #{comment.section.enrollment_limit}" %>
       </small>
       <small class="text-muted">
-        <%= "Cross List Enrollment: #{comment.section.cross_list_enrollment}" %>
+        <%= "X-List Total: #{comment.section.cross_list_enrollment}" %>
       </small>
     </div>
     <div class="section-info">
       <small class="text-muted">
-        <%= "Actual Enrollment: #{comment.section.actual_enrollment}" %>
+        <%= "Section Enrollment: #{comment.section.actual_enrollment}" %>
       </small>
       <small class="text-muted">
         <%= "Waitlist: #{comment.section.waitlist}" %>

--- a/app/views/comments_mailer/report.html.erb
+++ b/app/views/comments_mailer/report.html.erb
@@ -19,8 +19,8 @@
     <th scope="col">Comments This Week</th>
     <th scope="col">Most Recent Comment</th>
     <th scope="col">Enrollment Limit</th>
-    <th scope="col">Actual Enrollment</th>
-    <th scope="col">Cross-List Enrollment</th>
+    <th scope="col">Section Enrollment</th>
+    <th scope="col">X-List Total</th>
     <th scope="col">Waitlist</th>
   </tr>
   </thead>

--- a/app/views/reports/_report_table.html.erb
+++ b/app/views/reports/_report_table.html.erb
@@ -10,8 +10,8 @@
       <th>Comments Since Yesterday</th>
       <th>Most Recent Comment</th>
       <th>Enrollment Limit</th>
-      <th>Actual Enrollment</th>
-      <th>Cross-List Enrollment</th>
+      <th>Section Enrollment</th>
+      <th>X-List Total</th>
       <th>Waitlist</th>
       <th>Graph</th>
     </tr>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -42,7 +42,7 @@
                       data: <%= waitlist_history %>
                   },
                   {
-                      label: "Crosslist Enrollment",
+                      label: "Crosslist Total",
                       backgroundColor: "rgba(0,191,255,0.2)",
                       borderWidth: 2,
                       borderColor: "",
@@ -55,7 +55,7 @@
                       data: <%= cross_list_enrollment_history %>
                   },
                   {
-                      label: "Actual Enrollment",
+                      label: "Section Enrollment",
                       backgroundColor: "rgba(0,128,0,0.2)",
                       borderWidth: 2,
                       borderColor: "",

--- a/app/views/sections/_section_table.html.erb
+++ b/app/views/sections/_section_table.html.erb
@@ -16,8 +16,8 @@
     <th>Instructor(s)</th>
     <th>Status</th>
     <th>Enrollment Limit</th>
-    <th>Actual Enrollment</th>
-    <th>Cross List Enrollment</th>
+    <th>Section Enrollment</th>
+    <th>X-List Total</th>
     <th>Waitlist</th>
     <th>Added</th>
     <th>Canceled</th>

--- a/app/views/sections/show.html.erb
+++ b/app/views/sections/show.html.erb
@@ -40,7 +40,7 @@
             data: <%= @sections.waitlist_history %>
           },
           {
-            label: "Crosslist Enrollment",
+            label: "Crosslist Total",
             backgroundColor : "rgba(0,191,255,0.2)",
             borderWidth : 2,
             borderColor : "",
@@ -53,7 +53,7 @@
             data: <%= @sections.cross_list_enrollment_history %>
           },
           {
-            label: "Actual Enrollment",
+            label: "Section Enrollment",
             backgroundColor : "rgba(0,128,0,0.2)",
             borderWidth : 2,
             borderColor : "",


### PR DESCRIPTION
This branch makes some minor changes to some of the phrasing used to help give a clearer indication to users what certain data refers to do.

In the sections and reports tables, we changed "Actual Enrollment" to "Section Enrollment" and "Cross List Enrollment" to "X-List Total". We also made the change in the comment views and mailer.

The changes introduced here are just visual. No changes to how the data is processed or used were made.